### PR TITLE
Update Setup.sh

### DIFF
--- a/Setup.sh
+++ b/Setup.sh
@@ -39,8 +39,7 @@ func_install_requests(){
   #sudo apt-get -q update
   #sudo apt-get -q upgrade 
   sudo git pull
-  sudo apt-get install wget -y
-  sudo apt-get grep wget -y
+  sudo apt-get -y install wget grep
   sudo pip install --upgrade requests 
   sudo pip install configparser --upgrade
   sudo pip install BeautifulSoup --upgrade


### PR DESCRIPTION
This fixes the -y flag being passed after - causes -y to not be recognized apt-get -y install wget grep on one line will install without prompt. Minor thing, looks awesome and nice work :)